### PR TITLE
enhancement: refactor to maintain policy state in-memory

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -50,7 +50,7 @@ jobs:
   e2e-test:
     name: "E2E Test"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
     - name: Set up Go 1.17
       uses: actions/setup-go@v2

--- a/apis/v1alpha1/placementpolicy_types.go
+++ b/apis/v1alpha1/placementpolicy_types.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type (
@@ -78,13 +77,6 @@ type Policy struct {
 type PlacementPolicyStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-
-	//All pods that would fall under this policy
-	AllQualifyingPods sets.String `json:"allQualifyingPods,omitempty"`
-	//Pods assigned to nodes based on this policy - the length of which is considered the "current size"
-	PodsManagedByPolicy sets.String `json:"podsManagedByPolicy,omitempty"`
-	//Whether "current size" is equal to computed target size
-	TargetMet bool `json:"targetMet"`
 }
 
 //+kubebuilder:object:root=true

--- a/apis/v1alpha1/placementpolicy_types.go
+++ b/apis/v1alpha1/placementpolicy_types.go
@@ -81,10 +81,10 @@ type PlacementPolicyStatus struct {
 
 	//All pods that would fall under this policy
 	AllQualifyingPods sets.String `json:"allQualifyingPods,omitempty"`
-	//Pods assigned to nodes based on this policy - those which are considered when computing "current size"
+	//Pods assigned to nodes based on this policy - the length of which is considered the "current size"
 	PodsManagedByPolicy sets.String `json:"podsManagedByPolicy,omitempty"`
-	//Computed whenever a pod is added or removed from the "managed by" list; Policy is "met" when this value is equal to target
-	CurrentSize *intstr.IntOrString `json:"currentSize,omitempty"`
+	//Whether "current size" is equal to computed target size
+	TargetMet bool `json:"targetMet"`
 }
 
 //+kubebuilder:object:root=true

--- a/apis/v1alpha1/placementpolicy_types.go
+++ b/apis/v1alpha1/placementpolicy_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type (
@@ -77,6 +78,13 @@ type Policy struct {
 type PlacementPolicyStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+
+	//All pods that would fall under this policy
+	AllQualifyingPods sets.String `json:"allQualifyingPods,omitempty"`
+	//Pods assigned to nodes based on this policy - those which are considered when computing "current size"
+	PodsManagedByPolicy sets.String `json:"podsManagedByPolicy,omitempty"`
+	//Computed whenever a pod is added or removed from the "managed by" list; Policy is "met" when this value is equal to target
+	CurrentSize *intstr.IntOrString `json:"currentSize,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/pkg/plugins/placementpolicy/core/core.go
+++ b/pkg/plugins/placementpolicy/core/core.go
@@ -12,8 +12,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/sets"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -21,12 +19,8 @@ import (
 // Manager defines the interfaces for PlacementPolicy management.
 type Manager interface {
 	GetPlacementPolicyForPod(context.Context, *corev1.Pod) (*v1alpha1.PlacementPolicy, error)
-	RemovePodFromPolicy(*corev1.Pod)
-	AddPolicy(*v1alpha1.PlacementPolicy)
-	UpdatePolicy(*v1alpha1.PlacementPolicy, *v1alpha1.PlacementPolicy)
-	DeletePolicy(*v1alpha1.PlacementPolicy)
-	CalculateTrueTargetSize(specTarget *intstr.IntOrString, lenAllPods int, action v1alpha1.Action) (int, error)
-	AddPodToPolicy(context.Context, *corev1.Pod, *v1alpha1.PlacementPolicy) (*v1alpha1.PlacementPolicy, error)
+	RemovePodFromPolicy(*corev1.Pod) error
+	AddPodToPolicy(context.Context, *corev1.Pod, *v1alpha1.PlacementPolicy) (*PolicyInfo, error)
 }
 
 type PlacementPolicyManager struct {
@@ -39,13 +33,7 @@ type PlacementPolicyManager struct {
 	// ppLister is placementPolicy lister
 	ppLister pplisters.PlacementPolicyLister
 	// available policies by namespace
-	policies PlacementPolicies
-}
-
-type PlacementPolicies map[string]map[string]*v1alpha1.PlacementPolicy
-
-func NewPlacementPolicies() PlacementPolicies {
-	return make(PlacementPolicies)
+	policies PolicyInfos
 }
 
 func NewPlacementPolicyManager(
@@ -58,91 +46,21 @@ func NewPlacementPolicyManager(
 		snapshotSharedLister: snapshotSharedLister,
 		ppLister:             ppInformer.Lister(),
 		podLister:            podLister,
-		policies:             NewPlacementPolicies(),
+		policies:             NewPolicyInfos(),
 	}
-}
-
-func (m *PlacementPolicyManager) AddPolicy(policy *v1alpha1.PlacementPolicy) {
-	policyNamespace := policy.Namespace
-	policyName := policy.Name
-
-	namespacePolicies, exists := m.policies[policyNamespace]
-	if exists {
-		_, nameExists := namespacePolicies[policyName]
-		if nameExists {
-			return
-		}
-
-		m.policies[policyNamespace][policyName] = policy
-		return
-	}
-
-	var namespaceMap = make(map[string]*v1alpha1.PlacementPolicy)
-	namespaceMap[policyName] = policy
-
-	m.policies[policyNamespace] = namespaceMap
-}
-
-func (m *PlacementPolicyManager) DeletePolicy(policy *v1alpha1.PlacementPolicy) {
-	policyNamespace := policy.Namespace
-
-	namespacePolicies, exists := m.policies[policyNamespace]
-	if exists {
-		delete(namespacePolicies, policy.Name)
-	}
-}
-
-func (m *PlacementPolicyManager) UpdatePolicy(oldPolicy *v1alpha1.PlacementPolicy, newPolicy *v1alpha1.PlacementPolicy) {
-	namespace := oldPolicy.Namespace
-	oldName := oldPolicy.Name
-
-	newName := newPolicy.Name
-
-	nameUnchanged := oldName == newName
-
-	_, namespaceExists := m.policies[namespace]
-
-	//todo more complex comparison logic and merging needed
-	if namespaceExists {
-		if nameUnchanged {
-			m.policies[namespace][oldName] = newPolicy
-			return
-		}
-
-		delete(m.policies[namespace], oldName)
-		m.policies[namespace][newName] = newPolicy
-		return
-	}
-
-	var namespaceMap = make(map[string]*v1alpha1.PlacementPolicy)
-	namespaceMap[newName] = newPolicy
-	m.policies[namespace] = namespaceMap
 }
 
 // GetPlacementPolicyForPod returns the placement policy for the given pod
 func (m *PlacementPolicyManager) GetPlacementPolicyForPod(ctx context.Context, pod *corev1.Pod) (*v1alpha1.PlacementPolicy, error) {
-	podNamespace := pod.Namespace
-
-	namespaceList, namespaceExists := m.policies[podNamespace]
-
-	if !namespaceExists {
-		nsList, namespaceError := m.PopulateNamespacePolicies(podNamespace)
-		if namespaceError != nil {
-			return nil, namespaceError
-		}
-
-		for _, nsPolicy := range nsList {
-			namespaceList[nsPolicy.Name] = nsPolicy
-		}
+	ppList, err := m.ppLister.PlacementPolicies(pod.Namespace).List(labels.Everything())
+	if err != nil {
+		return nil, err
 	}
-
 	// filter the placement policy list based on the pod's labels
-	ppList := m.filterPlacementPolicyList(namespaceList, pod)
-
+	ppList = m.filterPlacementPolicyList(ppList, pod)
 	if len(ppList) == 0 {
 		return nil, nil
 	}
-
 	if len(ppList) > 1 {
 		// if there are multiple placement policies, sort them by weight and return the first one
 		sort.Sort(sort.Reverse(ByWeight(ppList)))
@@ -151,24 +69,7 @@ func (m *PlacementPolicyManager) GetPlacementPolicyForPod(ctx context.Context, p
 	return ppList[0], nil
 }
 
-func (m *PlacementPolicyManager) PopulateNamespacePolicies(namespace string) (map[string]*v1alpha1.PlacementPolicy, error) {
-	result := make(map[string]*v1alpha1.PlacementPolicy)
-
-	ppList, err := m.ppLister.PlacementPolicies(namespace).List(labels.Everything())
-	if err != nil {
-		return result, err
-	}
-
-	for _, pp := range ppList {
-		ppName := pp.Name
-		result[ppName] = pp
-	}
-
-	m.policies[namespace] = result
-	return result, nil
-}
-
-func (m *PlacementPolicyManager) filterPlacementPolicyList(ppList map[string]*v1alpha1.PlacementPolicy, pod *corev1.Pod) []*v1alpha1.PlacementPolicy {
+func (m *PlacementPolicyManager) filterPlacementPolicyList(ppList []*v1alpha1.PlacementPolicy, pod *corev1.Pod) []*v1alpha1.PlacementPolicy {
 	var filteredPPList []*v1alpha1.PlacementPolicy
 	for _, pp := range ppList {
 		labels := pp.Spec.PodSelector.MatchLabels
@@ -179,122 +80,79 @@ func (m *PlacementPolicyManager) filterPlacementPolicyList(ppList map[string]*v1
 	return filteredPPList
 }
 
-func (m *PlacementPolicyManager) RemovePodFromPolicy(pod *corev1.Pod) {
+func (m *PlacementPolicyManager) RemovePodFromPolicy(pod *corev1.Pod) error {
 	key, keyError := framework.GetPodKey(pod)
 	if keyError != nil {
+		return keyError
+	}
+
+	podNamespace := pod.Namespace
+	ppList := m.policies[podNamespace]
+
+	if ppList != nil {
+		var matchingPolicy *PolicyInfo
+
+		for _, pp := range ppList {
+			if pp.allQualifyingPods.Has(key) {
+				matchingPolicy = pp
+				break
+			}
+		}
+
+		if matchingPolicy != nil {
+			removeError := matchingPolicy.removePodIfPresent(pod)
+			if removeError != nil {
+				return removeError
+			}
+
+			m.upsertPolicyInfo(matchingPolicy, true)
+		}
+	}
+	return nil
+}
+
+func (m *PlacementPolicyManager) getInfoForPolicy(pp *v1alpha1.PlacementPolicy) (*PolicyInfo, bool) {
+	ppNamespace := pp.Namespace
+	ppName := pp.Name
+
+	namespace, exists := m.policies[ppNamespace]
+
+	if exists {
+		policy, policyExists := namespace[ppName]
+		if policyExists {
+			return policy, true
+		}
+	}
+
+	info := newPolicyInfo(ppNamespace, ppName, pp.Spec.Policy.Action, pp.Spec.Policy.TargetSize)
+	return info, false
+}
+
+func (m *PlacementPolicyManager) AddPodToPolicy(ctx context.Context, pod *corev1.Pod, pp *v1alpha1.PlacementPolicy) (*PolicyInfo, error) {
+	policy, exists := m.getInfoForPolicy(pp)
+	addError := policy.addPodIfNotPresent(pod)
+	m.upsertPolicyInfo(policy, exists)
+	return policy, addError
+}
+
+func (m *PlacementPolicyManager) upsertPolicyInfo(policy *PolicyInfo, exists bool) {
+	namespace := policy.Namespace
+	name := policy.Name
+
+	if exists {
+		existing := m.policies[namespace][name]
+		m.policies[namespace][name] = policy.merge(existing)
 		return
 	}
 
-	ppList := m.policies[pod.Namespace]
-
-	if ppList != nil {
-		var ppArray []*v1alpha1.PlacementPolicy
-		for _, pp := range ppList {
-			ppArray = append(ppArray, pp)
-		}
-
-		associated := getAssociatedPolicy(ppArray, key)
-		if associated != nil {
-			policyNamespace := associated.Namespace
-			policyName := associated.Name
-
-			status := associated.Status
-			act := associated.Spec.Policy.Action
-
-			delete(status.AllQualifyingPods, key)
-			podCount := len(status.AllQualifyingPods)
-
-			delete(status.PodsManagedByPolicy, key)
-
-			target, calcError := m.CalculateTrueTargetSize(associated.Spec.Policy.TargetSize, podCount, act)
-
-			targetMet := status.TargetMet
-			if calcError == nil {
-				managedCount := len(status.PodsManagedByPolicy)
-				targetMet = managedCount < target
-			}
-
-			updatedStatus := m.buildStatus(status.AllQualifyingPods, status.PodsManagedByPolicy, targetMet)
-			m.updateLocalPolicy(policyNamespace, policyName, *updatedStatus)
-		}
-	}
-}
-
-func getAssociatedPolicy(ppList []*v1alpha1.PlacementPolicy, key string) *v1alpha1.PlacementPolicy {
-	var matchingPolicy *v1alpha1.PlacementPolicy
-	for _, pp := range ppList {
-		ppStatus := pp.Status
-
-		if ppStatus.AllQualifyingPods.Has(key) {
-			matchingPolicy = pp
-			break
-		}
-	}
-	return matchingPolicy
-}
-
-func (m *PlacementPolicyManager) CalculateTrueTargetSize(specTarget *intstr.IntOrString, lenAllPods int, action v1alpha1.Action) (int, error) {
-	target, err := intstr.GetScaledValueFromIntOrPercent(specTarget, lenAllPods, false)
-
-	if err != nil {
-		return 0, err
+	namespacePolicies, namespaceExists := m.policies[namespace]
+	if !namespaceExists {
+		policies := make(map[string]*PolicyInfo)
+		policies[name] = policy
+		m.policies[namespace] = policies
+		return
 	}
 
-	if action == v1alpha1.ActionMustNot {
-		target = lenAllPods - target
-	}
-
-	return target, nil
-}
-
-func (m *PlacementPolicyManager) AddPodToPolicy(ctx context.Context, pod *corev1.Pod, pp *v1alpha1.PlacementPolicy) (*v1alpha1.PlacementPolicy, error) {
-	podKey, err := framework.GetPodKey(pod)
-	if err != nil {
-		return pp, err
-	}
-
-	policyNamespace := pp.Namespace
-	policyName := pp.Name
-
-	specTarget := pp.Spec.Policy.TargetSize
-
-	ppState := pp.Status
-
-	allPods := ppState.AllQualifyingPods.Insert(podKey) // add pod id to "all pods"
-	lenAllPods := len(allPods)                          //new "all pods"
-
-	calcTarget, targetErr := m.CalculateTrueTargetSize(specTarget, lenAllPods, pp.Spec.Policy.Action)
-	if targetErr != nil {
-		return pp, targetErr
-	}
-
-	managedPods := ppState.PodsManagedByPolicy
-	lenManaged := len(managedPods)
-
-	if lenManaged >= calcTarget {
-		//after re-calculating target, the number of pods currently managed by the policy meets or exceeds the calculated target
-		metState := m.buildStatus(allPods, managedPods, true)
-		updatedPolicy := m.updateLocalPolicy(policyNamespace, policyName, *metState)
-		return updatedPolicy, nil
-	}
-
-	managedPods = managedPods.Insert(podKey)
-	lenManaged = lenManaged + 1
-
-	updatedState := m.buildStatus(allPods, managedPods, (lenManaged >= calcTarget))
-	policy := m.updateLocalPolicy(policyNamespace, policyName, *updatedState)
-	return policy, nil
-}
-
-func (m *PlacementPolicyManager) updateLocalPolicy(namespace string, name string, updatedStatus v1alpha1.PlacementPolicyStatus) *v1alpha1.PlacementPolicy {
-	m.policies[namespace][name].Status = updatedStatus
-	return m.policies[namespace][name]
-}
-
-func (m *PlacementPolicyManager) buildStatus(allPods sets.String, managedPods sets.String, targetMet bool) *v1alpha1.PlacementPolicyStatus {
-	updatedState := new(v1alpha1.PlacementPolicyStatus)
-	updatedState.AllQualifyingPods = allPods
-	updatedState.PodsManagedByPolicy = managedPods
-	updatedState.TargetMet = targetMet
-	return updatedState
+	namespacePolicies[name] = policy
+	m.policies[namespace] = namespacePolicies
 }

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -135,7 +135,7 @@ func (p *PolicyInfo) setTargetMet() error {
 	}
 
 	managedCount := len(p.podsManagedByPolicy)
-	p.targetMet = managedCount < target
+	p.targetMet = managedCount <= target
 	return nil
 }
 

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -1,0 +1,158 @@
+package core
+
+import (
+	"github.com/Azure/placement-policy-scheduler-plugins/apis/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+type PolicyInfo struct {
+	Namespace           string
+	Name                string
+	Action              v1alpha1.Action
+	TargetSize          *intstr.IntOrString
+	allQualifyingPods   sets.String
+	podsManagedByPolicy sets.String
+	targetMet           bool
+}
+
+func newPolicyInfo(namespace string, name string, action v1alpha1.Action, targetSize *intstr.IntOrString) *PolicyInfo {
+	policy := &PolicyInfo{
+		Namespace:           namespace,
+		Name:                name,
+		Action:              action,
+		TargetSize:          targetSize,
+		allQualifyingPods:   sets.NewString(),
+		podsManagedByPolicy: sets.NewString(),
+		targetMet:           false,
+	}
+	return policy
+}
+
+type PolicyInfos map[string]map[string]*PolicyInfo
+
+func NewPolicyInfos() PolicyInfos {
+	return make(PolicyInfos)
+}
+
+func (p *PolicyInfo) merge(existing *PolicyInfo) *PolicyInfo {
+	existing.targetMet = p.targetMet
+	existing.allQualifyingPods = sets.NewString()
+	existing.podsManagedByPolicy = sets.NewString()
+
+	if len(p.allQualifyingPods) > 0 {
+		pods := p.allQualifyingPods.List()
+		for _, pod := range pods {
+			existing.allQualifyingPods.Insert(pod)
+		}
+	}
+
+	if len(p.podsManagedByPolicy) > 0 {
+		pods := p.podsManagedByPolicy.List()
+		for _, pod := range pods {
+			existing.podsManagedByPolicy.Insert(pod)
+		}
+	}
+
+	return existing
+}
+
+func (p *PolicyInfo) removePodIfPresent(pod *corev1.Pod) error {
+	key, keyError := framework.GetPodKey(pod)
+	if keyError != nil {
+		return keyError
+	}
+
+	if !p.PodQualifiesForPolicy(key) {
+		return nil
+	}
+
+	allQualifying := p.allQualifyingPods
+	p.allQualifyingPods = allQualifying.Delete(key)
+
+	if p.PodIsManagedByPolicy(key) {
+		managed := p.podsManagedByPolicy
+		p.podsManagedByPolicy = managed.Delete(key)
+	}
+
+	err := p.setTargetMet()
+	return err
+}
+
+func (p *PolicyInfo) addPodIfNotPresent(pod *corev1.Pod) error {
+	key, keyError := framework.GetPodKey(pod)
+	if keyError != nil {
+		return keyError
+	}
+
+	if p.PodQualifiesForPolicy(key) {
+		return nil
+	}
+
+	qualifyingPods := p.allQualifyingPods
+	p.allQualifyingPods = qualifyingPods.Insert(key)
+
+	targetMetWithoutNewPod, targetErr := p.computeTargetMet()
+	if targetErr != nil {
+		return targetErr
+	}
+
+	if targetMetWithoutNewPod {
+		p.targetMet = true
+		return nil
+	}
+
+	managedPods := p.podsManagedByPolicy
+	p.podsManagedByPolicy = managedPods.Insert(key)
+
+	setErr := p.setTargetMet()
+	return setErr
+}
+
+func (p *PolicyInfo) calculateTrueTargetSize() (int, error) {
+	specTarget := p.TargetSize
+	lenAllPods := len(p.allQualifyingPods)
+
+	target, err := intstr.GetScaledValueFromIntOrPercent(specTarget, lenAllPods, false)
+
+	if err != nil {
+		return 0, err
+	}
+
+	if p.Action == v1alpha1.ActionMustNot {
+		target = lenAllPods - target
+	}
+
+	return target, nil
+}
+
+func (p *PolicyInfo) setTargetMet() error {
+	targetMet, err := p.computeTargetMet()
+	if err != nil {
+		return err
+	}
+	p.targetMet = targetMet
+	return nil
+}
+
+func (p *PolicyInfo) computeTargetMet() (bool, error) {
+	target, calcError := p.calculateTrueTargetSize()
+	if calcError != nil {
+		return false, calcError
+	}
+
+	managedCount := len(p.podsManagedByPolicy)
+	targetMet := managedCount < target
+	return targetMet, nil
+}
+
+func (p *PolicyInfo) PodQualifiesForPolicy(podKey string) bool {
+	return p.allQualifyingPods.Has(podKey)
+}
+
+func (p *PolicyInfo) PodIsManagedByPolicy(podKey string) bool {
+	return p.podsManagedByPolicy.Has(podKey)
+}

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -135,7 +135,7 @@ func (p *PolicyInfo) setTargetMet() error {
 	}
 
 	managedCount := len(p.podsManagedByPolicy)
-	p.targetMet = managedCount <= target
+	p.targetMet = managedCount >= target //since the TargetSize is rounded down, the expectation that it will only meet/equal and never exceed
 	return nil
 }
 

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -72,10 +72,10 @@ func (p *PolicyInfo) removePodIfPresent(pod *corev1.Pod) error {
 		return nil
 	}
 
-	delete(p.allQualifyingPods, key)
+	p.allQualifyingPods = p.allQualifyingPods.Delete(key)
 
 	if p.PodIsManagedByPolicy(key) {
-		delete(p.podsManagedByPolicy, key)
+		p.podsManagedByPolicy = p.podsManagedByPolicy.Delete(key)
 	}
 
 	err := p.setTargetMet()

--- a/pkg/plugins/placementpolicy/core/policy_test.go
+++ b/pkg/plugins/placementpolicy/core/policy_test.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/Azure/placement-policy-scheduler-plugins/apis/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func TestAddPodIfNotPresent(t *testing.T) {
+	two := intstr.FromInt(2)
+	fiftyPercent := intstr.FromString("50%")
+	eightyPercent := intstr.FromString("80%")
+
+	tests := []struct {
+		name                 string
+		action               v1alpha1.Action
+		target               intstr.IntOrString
+		currentQualifiedPods sets.String
+		currentManagedPods   sets.String
+		podToAdd             *corev1.Pod
+		wantPolicyManaged    bool
+	}{
+		{
+			name:                 "target threshold not met - Must and no pods",
+			action:               v1alpha1.ActionMust,
+			target:               two,
+			currentQualifiedPods: sets.NewString(),
+			currentManagedPods:   sets.NewString(),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID("pod1")}},
+			wantPolicyManaged:    true,
+		},
+		{
+			name:                 "target threshold not met - Must with pods",
+			action:               v1alpha1.ActionMust,
+			target:               fiftyPercent,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4", "pod5"),
+			currentManagedPods:   sets.NewString("pod1", "pod2"),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod6", UID: types.UID("pod6")}},
+			wantPolicyManaged:    true,
+		},
+		{
+			name:                 "target threshold not met - MustNot and no pods",
+			action:               v1alpha1.ActionMustNot,
+			target:               fiftyPercent,
+			currentQualifiedPods: sets.NewString(),
+			currentManagedPods:   sets.NewString(),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID("pod1")}},
+			wantPolicyManaged:    true,
+		},
+		{
+			name:                 "target threshold not met - MustNot with pods",
+			action:               v1alpha1.ActionMustNot,
+			target:               fiftyPercent,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4", "pod5"),
+			currentManagedPods:   sets.NewString("pod1", "pod2"),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod6", UID: types.UID("pod6")}},
+			wantPolicyManaged:    true,
+		},
+		{
+			name:                 "target threshold met - Must",
+			action:               v1alpha1.ActionMust,
+			target:               two,
+			currentQualifiedPods: sets.NewString("pod1", "pod2"),
+			currentManagedPods:   sets.NewString("pod1", "pod2"),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3", UID: types.UID("pod3")}},
+			wantPolicyManaged:    false,
+		},
+		{
+			name:                 "target threshold met - MustNot",
+			action:               v1alpha1.ActionMustNot,
+			target:               eightyPercent,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4"),
+			currentManagedPods:   sets.NewString("pod1"),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod5", UID: types.UID("pod5")}},
+			wantPolicyManaged:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policyUnderTest := newPolicyInfo("ns", tt.name, tt.action, &tt.target)
+			policyUnderTest.allQualifyingPods = tt.currentQualifiedPods
+			policyUnderTest.podsManagedByPolicy = tt.currentManagedPods
+
+			policyUnderTest.addPodIfNotPresent(tt.podToAdd)
+			key, _ := framework.GetPodKey(tt.podToAdd)
+
+			podManaged := policyUnderTest.PodIsManagedByPolicy(key)
+
+			if podManaged != tt.wantPolicyManaged {
+				t.Errorf("policy %v, addPodIfNotPresent(%v), PodIsManagedByPolicy %v, wantPolicyManaged %v", policyUnderTest, tt.podToAdd, podManaged, tt.wantPolicyManaged)
+			}
+		})
+	}
+}

--- a/pkg/plugins/placementpolicy/core/policy_test.go
+++ b/pkg/plugins/placementpolicy/core/policy_test.go
@@ -17,6 +17,12 @@ func TestAddPodIfNotPresent(t *testing.T) {
 	fiftyPercent := intstr.FromString("50%")
 	eightyPercent := intstr.FromString("80%")
 
+	type desiredResult struct {
+		newPodManaged bool
+		targetMet     bool
+		valuesChanged bool
+	}
+
 	tests := []struct {
 		name                 string
 		action               v1alpha1.Action
@@ -24,61 +30,70 @@ func TestAddPodIfNotPresent(t *testing.T) {
 		currentQualifiedPods sets.String
 		currentManagedPods   sets.String
 		podToAdd             *corev1.Pod
-		wantPolicyManaged    bool
+		want                 desiredResult
 	}{
 		{
-			name:                 "target threshold not met - Must and no pods",
+			name:                 "Must - new pod managed - target not met",
 			action:               v1alpha1.ActionMust,
 			target:               two,
 			currentQualifiedPods: sets.NewString(),
 			currentManagedPods:   sets.NewString(),
 			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID("pod1")}},
-			wantPolicyManaged:    true,
+			want:                 desiredResult{newPodManaged: true, targetMet: false, valuesChanged: true},
 		},
 		{
-			name:                 "target threshold not met - Must with pods",
+			name:                 "Must - new pod managed - target met",
 			action:               v1alpha1.ActionMust,
 			target:               fiftyPercent,
 			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4", "pod5"),
 			currentManagedPods:   sets.NewString("pod1", "pod2"),
 			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod6", UID: types.UID("pod6")}},
-			wantPolicyManaged:    true,
+			want:                 desiredResult{newPodManaged: true, targetMet: true, valuesChanged: true},
 		},
 		{
-			name:                 "target threshold not met - MustNot and no pods",
+			name:                 "MustNot with no pods - new pod managed - target met",
 			action:               v1alpha1.ActionMustNot,
 			target:               fiftyPercent,
 			currentQualifiedPods: sets.NewString(),
 			currentManagedPods:   sets.NewString(),
 			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID("pod1")}},
-			wantPolicyManaged:    true,
+			want:                 desiredResult{newPodManaged: true, targetMet: true, valuesChanged: true},
 		},
 		{
-			name:                 "target threshold not met - MustNot with pods",
+			name:                 "MustNot with pods - new pod managed - target met",
 			action:               v1alpha1.ActionMustNot,
 			target:               fiftyPercent,
 			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4", "pod5"),
 			currentManagedPods:   sets.NewString("pod1", "pod2"),
 			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod6", UID: types.UID("pod6")}},
-			wantPolicyManaged:    true,
+			want:                 desiredResult{newPodManaged: true, targetMet: true, valuesChanged: true},
 		},
 		{
-			name:                 "target threshold met - Must",
+			name:                 "Must - new pod not managed - target met",
 			action:               v1alpha1.ActionMust,
 			target:               two,
 			currentQualifiedPods: sets.NewString("pod1", "pod2"),
 			currentManagedPods:   sets.NewString("pod1", "pod2"),
 			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3", UID: types.UID("pod3")}},
-			wantPolicyManaged:    false,
+			want:                 desiredResult{newPodManaged: false, targetMet: true, valuesChanged: true},
 		},
 		{
-			name:                 "target threshold met - MustNot",
+			name:                 "MustNot - new pod not managed - target met",
 			action:               v1alpha1.ActionMustNot,
 			target:               eightyPercent,
 			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4"),
 			currentManagedPods:   sets.NewString("pod1"),
 			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod5", UID: types.UID("pod5")}},
-			wantPolicyManaged:    false,
+			want:                 desiredResult{newPodManaged: false, targetMet: true, valuesChanged: true},
+		},
+		{
+			name:                 "pod already included - no change",
+			action:               v1alpha1.ActionMust,
+			target:               two,
+			currentQualifiedPods: sets.NewString("pod1", "pod2"),
+			currentManagedPods:   sets.NewString("pod1", "pod2"),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", UID: types.UID("pod2")}},
+			want:                 desiredResult{valuesChanged: false},
 		},
 	}
 
@@ -87,14 +102,239 @@ func TestAddPodIfNotPresent(t *testing.T) {
 			policyUnderTest := newPolicyInfo("ns", tt.name, tt.action, &tt.target)
 			policyUnderTest.allQualifyingPods = tt.currentQualifiedPods
 			policyUnderTest.podsManagedByPolicy = tt.currentManagedPods
+			policyUnderTest.setTargetMet() //since testing includes "no changes", this must be computed before addition
+			copyOfOriginal := policyUnderTest
 
 			policyUnderTest.addPodIfNotPresent(tt.podToAdd)
-			key, _ := framework.GetPodKey(tt.podToAdd)
+			resultTargetMet := policyUnderTest.targetMet
 
-			podManaged := policyUnderTest.PodIsManagedByPolicy(key)
+			if !tt.want.valuesChanged {
+				originalQualifying := len(copyOfOriginal.allQualifyingPods)
+				resultQualifying := len(policyUnderTest.allQualifyingPods)
+				if resultQualifying != originalQualifying {
+					t.Errorf("No changes expected but allQualifyingPods changed. Original: %v Final: %v", originalQualifying, resultQualifying)
+				}
+				originalManaged := len(copyOfOriginal.podsManagedByPolicy)
+				resultManaged := len(policyUnderTest.podsManagedByPolicy)
+				if resultManaged != originalManaged {
+					t.Errorf("No changes expected but podsManagedByPolicy did. Original: %v Final: %v", originalManaged, resultManaged)
+				}
+				if copyOfOriginal.targetMet != resultTargetMet {
+					t.Errorf("No changes expected but targetMet changed. Original: %v Final: %v", copyOfOriginal.targetMet, resultTargetMet)
+				}
+			} else {
+				if tt.want.targetMet != resultTargetMet {
+					t.Errorf("targetMet mismatch. Expected: %v Actual: %v", tt.want.targetMet, resultTargetMet)
+				}
 
-			if podManaged != tt.wantPolicyManaged {
-				t.Errorf("policy %v, addPodIfNotPresent(%v), PodIsManagedByPolicy %v, wantPolicyManaged %v", policyUnderTest, tt.podToAdd, podManaged, tt.wantPolicyManaged)
+				key, _ := framework.GetPodKey(tt.podToAdd)
+				if tt.want.newPodManaged && !policyUnderTest.PodIsManagedByPolicy(key) {
+					t.Errorf("Expected added pod to be managed by policy but it isn't.")
+				}
+			}
+
+		})
+	}
+}
+
+func TestRemovePodIfPresent(t *testing.T) {
+	two := intstr.FromInt(2)
+	three := intstr.FromInt(3)
+	seventyFivePercent := intstr.FromString("75%")
+	eightyPercent := intstr.FromString("80%")
+
+	type desiredResult struct {
+		qualifyingCount int
+		managedCount    int
+		targetMet       bool
+	}
+
+	tests := []struct {
+		name                 string
+		action               v1alpha1.Action
+		target               intstr.IntOrString
+		currentQualifiedPods sets.String
+		currentManagedPods   sets.String
+		podToRemove          *corev1.Pod
+		want                 desiredResult
+	}{
+		{
+			name:                 "pod not included - no change",
+			action:               v1alpha1.ActionMust,
+			target:               two,
+			currentQualifiedPods: sets.NewString("pod1", "pod2"),
+			currentManagedPods:   sets.NewString("pod1", "pod2"),
+			podToRemove:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod5", UID: types.UID("pod5")}},
+			want:                 desiredResult{qualifyingCount: 2, managedCount: 2, targetMet: true},
+		},
+		{
+			name:                 "Must - target not met",
+			action:               v1alpha1.ActionMust,
+			target:               two,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4"),
+			currentManagedPods:   sets.NewString("pod1", "pod3"),
+			podToRemove:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID("pod1")}},
+			want:                 desiredResult{qualifyingCount: 3, managedCount: 1, targetMet: false},
+		},
+		{
+			name:                 "Must - target met",
+			action:               v1alpha1.ActionMust,
+			target:               seventyFivePercent,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4"),
+			currentManagedPods:   sets.NewString("pod1", "pod2", "pod3"),
+			podToRemove:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod4", UID: types.UID("pod4")}},
+			want:                 desiredResult{qualifyingCount: 3, managedCount: 3, targetMet: true},
+		},
+		{
+			name:                 "MustNot - target met",
+			action:               v1alpha1.ActionMustNot,
+			target:               eightyPercent,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4"),
+			currentManagedPods:   sets.NewString("pod1", "pod3"),
+			podToRemove:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID("pod1")}},
+			want:                 desiredResult{qualifyingCount: 3, managedCount: 1, targetMet: true},
+		},
+		{
+			name:                 "MustNot - target not met",
+			action:               v1alpha1.ActionMustNot,
+			target:               three,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4", "pod5", "pod6", "pod7", "pod8", "pod9"),
+			currentManagedPods:   sets.NewString("pod1", "pod2", "pod3"),
+			podToRemove:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3", UID: types.UID("pod3")}},
+			want:                 desiredResult{qualifyingCount: 8, managedCount: 2, targetMet: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policyUnderTest := newPolicyInfo("ns", tt.name, tt.action, &tt.target)
+			policyUnderTest.allQualifyingPods = tt.currentQualifiedPods
+			policyUnderTest.podsManagedByPolicy = tt.currentManagedPods
+			policyUnderTest.setTargetMet() //since testing includes "no changes", this must be computed before removal
+
+			policyUnderTest.removePodIfPresent(tt.podToRemove)
+
+			actualQualifyingCount := len(policyUnderTest.allQualifyingPods)
+			if actualQualifyingCount != tt.want.qualifyingCount {
+				t.Errorf("allQualifyingPods length: expected: %v actual: %v", tt.want.qualifyingCount, actualQualifyingCount)
+			}
+
+			actualManagedCount := len(policyUnderTest.podsManagedByPolicy)
+			if actualManagedCount != tt.want.managedCount {
+				t.Errorf("podsManagedByPolicy length: expected: %v actual: %v", tt.want.managedCount, actualManagedCount)
+			}
+
+			if policyUnderTest.targetMet != tt.want.targetMet {
+				t.Errorf("targetMet: expected: %v actual: %v", tt.want.targetMet, policyUnderTest.targetMet)
+			}
+		})
+	}
+}
+
+func TestPolicyInfoMerge(t *testing.T) {
+	type policyInput struct {
+		action        v1alpha1.Action
+		target        intstr.IntOrString
+		qualifiedPods sets.String
+		managedPods   sets.String
+	}
+
+	tenPercent := intstr.FromString("10%")
+	five := intstr.FromInt(5)
+
+	tests := []struct {
+		name     string
+		existing policyInput
+		updated  policyInput
+	}{
+		{
+			name:     "action updated",
+			existing: policyInput{action: v1alpha1.ActionMust, target: tenPercent, qualifiedPods: sets.NewString("pod1"), managedPods: sets.NewString("pod1")},
+			updated:  policyInput{action: v1alpha1.ActionMustNot, target: tenPercent, qualifiedPods: sets.NewString("pod1"), managedPods: sets.NewString("pod1")},
+		},
+		{
+			name:     "target updated",
+			existing: policyInput{action: v1alpha1.ActionMust, target: five, qualifiedPods: sets.NewString("pod1"), managedPods: sets.NewString("pod1")},
+			updated:  policyInput{action: v1alpha1.ActionMust, target: tenPercent, qualifiedPods: sets.NewString("pod1"), managedPods: sets.NewString("pod1")},
+		},
+		{
+			name:     "number of pods updated",
+			existing: policyInput{action: v1alpha1.ActionMust, target: five, qualifiedPods: sets.NewString("pod1"), managedPods: sets.NewString()},
+			updated:  policyInput{action: v1alpha1.ActionMust, target: five, qualifiedPods: sets.NewString("pod1", "pod2"), managedPods: sets.NewString("pod2")},
+		},
+		{
+			name:     "value of pods updated",
+			existing: policyInput{action: v1alpha1.ActionMust, target: five, qualifiedPods: sets.NewString("pod5", "pod25"), managedPods: sets.NewString("pod5")},
+			updated:  policyInput{action: v1alpha1.ActionMust, target: five, qualifiedPods: sets.NewString("pod1", "pod2"), managedPods: sets.NewString("pod2")},
+		},
+	}
+
+	policyNamespace := "ns"
+	policyName := "placement_policy"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existingPolicy := &PolicyInfo{
+				Namespace:           policyNamespace,
+				Name:                policyName,
+				Action:              tt.existing.action,
+				TargetSize:          &tt.existing.target,
+				allQualifyingPods:   tt.existing.qualifiedPods,
+				podsManagedByPolicy: tt.existing.managedPods,
+			}
+			existingPolicy.setTargetMet()
+
+			updatedPolicy := &PolicyInfo{
+				Namespace:           policyNamespace,
+				Name:                policyName,
+				Action:              tt.updated.action,
+				TargetSize:          &tt.updated.target,
+				allQualifyingPods:   tt.updated.qualifiedPods,
+				podsManagedByPolicy: tt.updated.managedPods,
+			}
+			updatedPolicy.setTargetMet()
+
+			final := updatedPolicy.merge(existingPolicy)
+			final.setTargetMet()
+
+			if final.Action != updatedPolicy.Action {
+				t.Errorf("Unexpected Action value - existing: %v, updated: %v, final: %v", existingPolicy.Action, updatedPolicy.Action, final.Action)
+			}
+
+			if final.TargetSize != updatedPolicy.TargetSize {
+				t.Errorf("Unexpected TargetSize value - existing: %v, updated: %v, final: %v", existingPolicy.TargetSize, updatedPolicy.TargetSize, final.TargetSize)
+			}
+
+			finalQualifying := final.allQualifyingPods.List()
+			for _, qp := range finalQualifying {
+				if !updatedPolicy.allQualifyingPods.Has(qp) {
+					t.Errorf("Unexpected value in allQualifyingPods - value %v exists in final and not in updated", qp)
+				}
+			}
+
+			updatedQualifying := updatedPolicy.allQualifyingPods.List()
+			for _, up := range updatedQualifying {
+				if !final.allQualifyingPods.Has(up) {
+					t.Errorf("Unexpected value in allQualifyingPods - value %v exists in updated and not in final", up)
+				}
+			}
+
+			finalManaged := final.podsManagedByPolicy.List()
+			for _, qp := range finalManaged {
+				if !updatedPolicy.podsManagedByPolicy.Has(qp) {
+					t.Errorf("Unexpected value in podsManagedByPolicy - value %v exists in final and not in updated", qp)
+				}
+			}
+
+			updatedManaged := updatedPolicy.podsManagedByPolicy.List()
+			for _, up := range updatedManaged {
+				if !final.podsManagedByPolicy.Has(up) {
+					t.Errorf("Unexpected value in podsManagedByPolicy - value %v exists in updated and not in final", up)
+				}
+			}
+
+			if final.targetMet != updatedPolicy.targetMet {
+				t.Errorf("Unexpected targetMet value - existing: %v, updated: %v, final: %v", existingPolicy.targetMet, updatedPolicy.targetMet, final.targetMet)
 			}
 		})
 	}

--- a/pkg/plugins/placementpolicy/placementpolicy.go
+++ b/pkg/plugins/placementpolicy/placementpolicy.go
@@ -44,11 +44,7 @@ func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) 
 	ppInformerFactory := ppinformers.NewSharedInformerFactory(ppClient, 0)
 	ppInformer := ppInformerFactory.Placementpolicy().V1alpha1().PlacementPolicies()
 
-	ppMgr := core.NewPlacementPolicyManager(
-		ppClient,
-		handle.SnapshotSharedLister(),
-		ppInformer,
-		handle.SharedInformerFactory().Core().V1().Pods().Lister())
+	ppMgr := core.NewPlacementPolicyManager(ppInformer)
 
 	plugin := &Plugin{
 		frameworkHandler: handle,

--- a/pkg/plugins/placementpolicy/state.go
+++ b/pkg/plugins/placementpolicy/state.go
@@ -2,6 +2,7 @@ package placementpolicy
 
 import (
 	"github.com/Azure/placement-policy-scheduler-plugins/apis/v1alpha1"
+	"github.com/Azure/placement-policy-scheduler-plugins/pkg/plugins/placementpolicy/core"
 
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -9,12 +10,14 @@ import (
 type stateData struct {
 	name string
 	pp   *v1alpha1.PlacementPolicy
+	info *core.PolicyInfo
 }
 
-func NewStateData(name string, pp *v1alpha1.PlacementPolicy) framework.StateData {
+func NewStateData(name string, pp *v1alpha1.PlacementPolicy, info *core.PolicyInfo) framework.StateData {
 	return &stateData{
 		name: name,
 		pp:   pp,
+		info: info,
 	}
 }
 


### PR DESCRIPTION
Re: #25 

[The capacity scheduling plugin](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/capacityscheduling) was used for frame of reference. A collection of policy information is kept in-memory on the PlacementPolicyManager. Instead of annotations, the policy info in the collection includes 2 sets:
- all pods that qualify for / fall under the policy
- all pods assigned to nodes in accordance with the policy ("managed by")

An event handler was attached to the pod informer so pod deletion can trigger updating the in-memory version of the policy accordingly. Additionally, the custom info object is included in the state object added to cycle state as a part of `PreFilter` and `PreScore` stages so that `Filter` and `Score` stages have access to it as well.

