### PR TITLE
ci: add workflow for publishing helm charts

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -1,0 +1,28 @@
+name: publish_helm_chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/chart.yaml"
+      - "charts/**"
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Publish Helm chart
+        uses: stefanprodan/helm-gh-pages@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: charts
+          target_dir: charts
+          linting: off

--- a/Makefile
+++ b/Makefile
@@ -147,3 +147,13 @@ docker-build: docker-buildx-builder
 		--platform="linux/amd64" \
 		--pull \
 		--tag $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION) .
+
+## --------------------------------------
+## Release
+## --------------------------------------
+
+.PHONY: promote-staging-manifest
+promote-staging-manifest:
+	@rm -rf deploy charts/placement-policy-scheduler-plugins
+	@cp -r manifest_staging/deploy .
+	@cp -r manifest_staging/charts .


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adds workflow for publishing helm charts in `gh-pages`
- Adds a make target for promoting manifests during release