### PR TITLE
feat: refactor to maintain policy state in-memory

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -50,7 +50,7 @@ jobs:
   e2e-test:
     name: "E2E Test"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
     - name: Set up Go 1.17
       uses: actions/setup-go@v2

--- a/pkg/plugins/placementpolicy/core/core.go
+++ b/pkg/plugins/placementpolicy/core/core.go
@@ -18,9 +18,9 @@ import (
 type Manager interface {
 	GetPlacementPolicyForPod(context.Context, *corev1.Pod) (*v1alpha1.PlacementPolicy, error)
 	GetPolicyInfo(*v1alpha1.PlacementPolicy) *PolicyInfo
-	MatchPodToPolicy(context.Context, *corev1.Pod, *PolicyInfo) (*PolicyInfo, error)
-	AddPodToPolicy(context.Context, *corev1.Pod, *PolicyInfo) (*PolicyInfo, error)
-	RemovePodFromPolicy(*corev1.Pod) error
+	MatchPod(context.Context, *corev1.Pod, *PolicyInfo) (*PolicyInfo, error)
+	AddPod(context.Context, *corev1.Pod, *PolicyInfo) (*PolicyInfo, error)
+	RemovePod(*corev1.Pod) error
 }
 
 type PlacementPolicyManager struct {
@@ -101,7 +101,7 @@ const (
 	Remove
 )
 
-func (m *PlacementPolicyManager) MatchPodToPolicy(ctx context.Context, pod *corev1.Pod, policy *PolicyInfo) (*PolicyInfo, error) {
+func (m *PlacementPolicyManager) MatchPod(ctx context.Context, pod *corev1.Pod, policy *PolicyInfo) (*PolicyInfo, error) {
 	matchError := policy.addMatch(pod)
 	if matchError != nil {
 		return nil, matchError
@@ -111,7 +111,7 @@ func (m *PlacementPolicyManager) MatchPodToPolicy(ctx context.Context, pod *core
 	return policy, nil
 }
 
-func (m *PlacementPolicyManager) AddPodToPolicy(ctx context.Context, pod *corev1.Pod, policy *PolicyInfo) (*PolicyInfo, error) {
+func (m *PlacementPolicyManager) AddPod(ctx context.Context, pod *corev1.Pod, policy *PolicyInfo) (*PolicyInfo, error) {
 	addError := policy.addPodIfNotPresent(pod)
 	if addError != nil {
 		return nil, addError
@@ -121,7 +121,7 @@ func (m *PlacementPolicyManager) AddPodToPolicy(ctx context.Context, pod *corev1
 	return policy, nil
 }
 
-func (m *PlacementPolicyManager) RemovePodFromPolicy(pod *corev1.Pod) error {
+func (m *PlacementPolicyManager) RemovePod(pod *corev1.Pod) error {
 	key, keyError := framework.GetPodKey(pod)
 	if keyError != nil {
 		return keyError
@@ -163,9 +163,6 @@ func (m *PlacementPolicyManager) updatePolicies(policy *PolicyInfo, act PodActio
 			delete(m.policies[namespace], name)
 			return
 		}
-
-		m.policies[namespace][name] = policy
-		return
 	}
 
 	existing := m.policies[namespace][name]

--- a/pkg/plugins/placementpolicy/core/core.go
+++ b/pkg/plugins/placementpolicy/core/core.go
@@ -102,7 +102,7 @@ const (
 )
 
 func (m *PlacementPolicyManager) MatchPod(ctx context.Context, pod *corev1.Pod, policy *PolicyInfo) (*PolicyInfo, error) {
-	matchError := policy.addMatch(pod)
+	err := policy.addMatch(pod)
 	if matchError != nil {
 		return nil, matchError
 	}

--- a/pkg/plugins/placementpolicy/core/core.go
+++ b/pkg/plugins/placementpolicy/core/core.go
@@ -18,7 +18,6 @@ import (
 type Manager interface {
 	GetPlacementPolicyForPod(context.Context, *corev1.Pod) (*v1alpha1.PlacementPolicy, error)
 	GetPolicyInfo(*v1alpha1.PlacementPolicy) *PolicyInfo
-	MatchPod(context.Context, *corev1.Pod, *PolicyInfo) (*PolicyInfo, error)
 	AddPod(context.Context, *corev1.Pod, *PolicyInfo) (*PolicyInfo, error)
 	RemovePod(*corev1.Pod) error
 }
@@ -86,17 +85,6 @@ const (
 	Add
 	Remove
 )
-
-// MatchPod attaches the provided pod to the provided PolicyInfo as a match
-func (m *PlacementPolicyManager) MatchPod(ctx context.Context, pod *corev1.Pod, policy *PolicyInfo) (*PolicyInfo, error) {
-	err := policy.addMatch(pod)
-	if err != nil {
-		return nil, err
-	}
-
-	m.updatePolicies(policy, Match)
-	return policy, nil
-}
 
 // AddPod adds the provided pod to the provided PolicyInfo and calculates whether target was met
 func (m *PlacementPolicyManager) AddPod(ctx context.Context, pod *corev1.Pod, policy *PolicyInfo) (*PolicyInfo, error) {

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -1,8 +1,9 @@
 package core
 
 import (
-	"github.com/Azure/placement-policy-scheduler-plugins/apis/v1alpha1"
+	"sync"
 
+	"github.com/Azure/placement-policy-scheduler-plugins/apis/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -34,10 +35,68 @@ func newPolicyInfo(namespace string, name string, action v1alpha1.Action, target
 	return policy
 }
 
-type PolicyInfos map[string]map[string]*PolicyInfo
+type PolicyInfos struct {
+	sync.RWMutex
+	internal map[string]map[string]*PolicyInfo
+}
 
 func NewPolicyInfos() PolicyInfos {
-	return make(PolicyInfos)
+	return PolicyInfos{
+		internal: make(map[string]map[string]*PolicyInfo),
+	}
+}
+
+// GetPolicy gets the PolicyInfo if it exists, otherwise it creates and returns the newly created PolicyInfo
+func (pi *PolicyInfos) GetPolicy(policyNamespace string, policyName string, action v1alpha1.Action, targetSize *intstr.IntOrString) *PolicyInfo {
+	var policy *PolicyInfo = nil
+	var policyExists bool = false
+
+	pi.RLock()
+	namespacePolicies, namespaceExists := pi.internal[policyNamespace]
+	if namespaceExists {
+		policy, policyExists = namespacePolicies[policyName]
+	}
+	pi.RUnlock()
+
+	if policyExists {
+		return policy
+	}
+
+	pi.Lock()
+	if !namespaceExists {
+		pi.internal[policyNamespace] = make(map[string]*PolicyInfo)
+	}
+
+	created := newPolicyInfo(policyNamespace, policyName, action, targetSize)
+	pi.internal[policyNamespace][policyName] = created
+
+	pi.Unlock()
+
+	return created
+}
+
+// RemovePolicy removes the policy from the in-memory collection
+func (pi *PolicyInfos) RemovePolicy(policyNamespace string, policyName string) {
+	pi.Lock()
+	delete(pi.internal[policyNamespace], policyName)
+	pi.Unlock()
+}
+
+// GetPoliciesByNamespace returns all policies in the namespace
+func (pi *PolicyInfos) GetPoliciesByNamespace(policyNamespace string) map[string]*PolicyInfo {
+	pi.RLock()
+	namespacePolicies := pi.internal[policyNamespace]
+	pi.RUnlock()
+	return namespacePolicies
+}
+
+// UpdatePolicy updates the policy held in-memory
+func (pi *PolicyInfos) UpdatePolicy(policyNamespace string, policy *PolicyInfo) {
+	policyName := policy.Name
+	pi.Lock()
+	existing := pi.internal[policyNamespace][policyName]
+	pi.internal[policyNamespace][policyName] = policy.merge(existing)
+	pi.Unlock()
 }
 
 func (p *PolicyInfo) merge(existing *PolicyInfo) *PolicyInfo {
@@ -47,48 +106,41 @@ func (p *PolicyInfo) merge(existing *PolicyInfo) *PolicyInfo {
 
 	tempMatched := sets.NewString()
 	if len(p.matchedPods) > 0 {
-		pods := p.matchedPods.List()
-		for _, pod := range pods {
-			tempMatched = tempMatched.Insert(pod)
-		}
+		tempMatched = tempMatched.Insert(p.matchedPods.List()...)
 	}
 	existing.matchedPods = tempMatched
 
 	tempQualified := sets.NewString()
 	if len(p.qualifiedPods) > 0 {
-		pods := p.qualifiedPods.List()
-		for _, pod := range pods {
-			tempQualified = tempQualified.Insert(pod)
-		}
+		tempQualified = tempQualified.Insert(p.qualifiedPods.List()...)
 	}
 	existing.qualifiedPods = tempQualified
 
 	tempManaged := sets.NewString()
 	if len(p.managedPods) > 0 {
-		pods := p.managedPods.List()
-		for _, pod := range pods {
-			tempManaged = tempManaged.Insert(pod)
-		}
+		tempManaged = tempManaged.Insert(p.managedPods.List()...)
 	}
 	existing.managedPods = tempManaged
 
 	return existing
 }
 
+// addMatch adds the pod to the policy's matchedPods collection
 func (p *PolicyInfo) addMatch(pod *corev1.Pod) error {
 	key, err := framework.GetPodKey(pod)
-	if keyError != nil {
-		return keyError
+	if err != nil {
+		return err
 	}
 
 	p.matchedPods = p.matchedPods.Insert(key)
 	return nil
 }
 
+// removePodIfPresent removes the pod from the policy's qualifiedPods and managedPods collections as appropriate
 func (p *PolicyInfo) removePodIfPresent(pod *corev1.Pod) error {
-	key, keyError := framework.GetPodKey(pod)
-	if keyError != nil {
-		return keyError
+	key, err := framework.GetPodKey(pod)
+	if err != nil {
+		return err
 	}
 
 	if !p.PodQualifiesForPolicy(key) {
@@ -101,10 +153,10 @@ func (p *PolicyInfo) removePodIfPresent(pod *corev1.Pod) error {
 		p.managedPods = p.managedPods.Delete(key)
 	}
 
-	err := p.setTargetMet()
-	return err
+	return p.setTargetMet()
 }
 
+// addPodIfNotPresent adds the pod to the policy's qualifiedPods and managedPods collections as appropriate
 func (p *PolicyInfo) addPodIfNotPresent(pod *corev1.Pod) error {
 	key, keyError := framework.GetPodKey(pod)
 	if keyError != nil {
@@ -119,7 +171,7 @@ func (p *PolicyInfo) addPodIfNotPresent(pod *corev1.Pod) error {
 	//if policy is `BestEffort`, this will be true
 	if p.PodMatchesPolicy(key) {
 		p.matchedPods = p.matchedPods.Delete(key) //once added, don't need to worry about matched anymore
-	} 
+	}
 
 	p.qualifiedPods = p.qualifiedPods.Insert(key)
 
@@ -134,18 +186,17 @@ func (p *PolicyInfo) addPodIfNotPresent(pod *corev1.Pod) error {
 	}
 
 	p.managedPods = p.managedPods.Insert(key)
-	err := p.setTargetMet()
-	return err
+	return p.setTargetMet()
 }
 
 func (p *PolicyInfo) setTargetMet() error {
 	specTarget := p.TargetSize
 	lenAllPods := len(p.qualifiedPods)
 
-	target, calcError := intstr.GetScaledValueFromIntOrPercent(specTarget, lenAllPods, false)
+	target, err := intstr.GetScaledValueFromIntOrPercent(specTarget, lenAllPods, false)
 
-	if calcError != nil {
-		return calcError
+	if err != nil {
+		return err
 	}
 
 	if p.Action == v1alpha1.ActionMustNot {
@@ -157,14 +208,17 @@ func (p *PolicyInfo) setTargetMet() error {
 	return nil
 }
 
+// PodMatchesPolicy returns whether or not the pod key is matched to the BestEffort policy during Filter
 func (p *PolicyInfo) PodMatchesPolicy(podKey string) bool {
 	return p.matchedPods.Has(podKey)
 }
 
+// PodQualifiesForPolicy returns whether or not the pod key is in the list of qualifying pods
 func (p *PolicyInfo) PodQualifiesForPolicy(podKey string) bool {
 	return p.qualifiedPods.Has(podKey)
 }
 
+// PodIsManagedByPolicy returns whether or not the pod key is in the list of pods assigned to node(s) in accordance with the policy
 func (p *PolicyInfo) PodIsManagedByPolicy(podKey string) bool {
 	return p.managedPods.Has(podKey)
 }

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -11,13 +11,21 @@ import (
 )
 
 type PolicyInfo struct {
+	//policy's namespace - from CRD
 	Namespace     string
+	//policy's name - from CRD
 	Name          string
+	//policy's action - from CRD
 	Action        v1alpha1.Action
+	//policy's target - from CRD
 	TargetSize    *intstr.IntOrString
+	//collection of pods matched if the policy is `BestEffort`; **not** used for computation
 	matchedPods   sets.String
+	//collection of pods that could be managed by the policy; used for computation as the **total**
 	qualifiedPods sets.String
+	//collection of pods assigned to a node according to the policy; used for computation
 	managedPods   sets.String
+	//does the ratio of managed-to-qualified meet the `TargetSize`
 	targetMet     bool
 }
 
@@ -37,6 +45,7 @@ func newPolicyInfo(namespace string, name string, action v1alpha1.Action, target
 
 type PolicyInfos struct {
 	sync.RWMutex
+	//map (by `Namespace`) of map (by `Name`) of `PolicyInfo`
 	internal map[string]map[string]*PolicyInfo
 }
 

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -76,7 +76,7 @@ func (p *PolicyInfo) merge(existing *PolicyInfo) *PolicyInfo {
 }
 
 func (p *PolicyInfo) addMatch(pod *corev1.Pod) error {
-	key, keyError := framework.GetPodKey(pod)
+	key, err := framework.GetPodKey(pod)
 	if keyError != nil {
 		return keyError
 	}

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -13,7 +13,7 @@ import (
 type PolicyInfo struct {
 	// PlacementPolicy namespace - from CRD
 	Namespace     string
-	//policy's name - from CRD
+	// PlacementPolicy name - from CRD
 	Name          string
 	//policy's action - from CRD
 	Action        v1alpha1.Action

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -167,7 +167,7 @@ func (p *PolicyInfo) removePodIfPresent(pod *corev1.Pod) error {
 
 // addPodIfNotPresent adds the pod to the policy's qualifiedPods and managedPods collections as appropriate
 func (p *PolicyInfo) addPodIfNotPresent(pod *corev1.Pod) error {
-	key, keyError := framework.GetPodKey(pod)
+	key, err := framework.GetPodKey(pod)
 	if keyError != nil {
 		return keyError
 	}

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -185,7 +185,7 @@ func (p *PolicyInfo) addPodIfNotPresent(pod *corev1.Pod) error {
 
 	p.qualifiedPods = p.qualifiedPods.Insert(key)
 
-	targetError := p.setTargetMet()
+	err := p.setTargetMet()
 	if targetError != nil {
 		return targetError
 	}

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -172,7 +172,7 @@ func (p *PolicyInfo) addPodIfNotPresent(pod *corev1.Pod) error {
 		return keyError
 	}
 
-	//if pod is already in the list, do nothing
+	// if pod is already in the list, do nothing
 	if p.PodQualifiesForPolicy(key) {
 		return nil
 	}

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -204,7 +204,6 @@ func (p *PolicyInfo) setTargetMet() error {
 	lenAllPods := len(p.qualifiedPods)
 
 	target, err := intstr.GetScaledValueFromIntOrPercent(specTarget, lenAllPods, false)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -179,7 +179,8 @@ func (p *PolicyInfo) addPodIfNotPresent(pod *corev1.Pod) error {
 
 	//if policy is `BestEffort`, this will be true
 	if p.PodMatchesPolicy(key) {
-		p.matchedPods = p.matchedPods.Delete(key) //once added, don't need to worry about matched anymore
+                // once added, don't need to worry about matched anymore
+		p.matchedPods = p.matchedPods.Delete(key) 
 	}
 
 	p.qualifiedPods = p.qualifiedPods.Insert(key)

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -11,7 +11,7 @@ import (
 )
 
 type PolicyInfo struct {
-	//policy's namespace - from CRD
+	// PlacementPolicy namespace - from CRD
 	Namespace     string
 	//policy's name - from CRD
 	Name          string

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -81,7 +81,7 @@ func (p *PolicyInfo) addMatch(pod *corev1.Pod) error {
 		return keyError
 	}
 
-	p.matchedPods = p.managedPods.Insert(key)
+	p.matchedPods = p.matchedPods.Insert(key)
 	return nil
 }
 
@@ -116,7 +116,10 @@ func (p *PolicyInfo) addPodIfNotPresent(pod *corev1.Pod) error {
 		return nil
 	}
 
-	p.matchedPods = p.matchedPods.Delete(key) //once added, don't need to worry about matched anymore
+	//if policy is `BestEffort`, this will be true
+	if p.PodMatchesPolicy(key) {
+		p.matchedPods = p.matchedPods.Delete(key) //once added, don't need to worry about matched anymore
+	} 
 
 	p.qualifiedPods = p.qualifiedPods.Insert(key)
 

--- a/pkg/plugins/placementpolicy/core/policy.go
+++ b/pkg/plugins/placementpolicy/core/policy.go
@@ -1,0 +1,148 @@
+package core
+
+import (
+	"github.com/Azure/placement-policy-scheduler-plugins/apis/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+type PolicyInfo struct {
+	Namespace           string
+	Name                string
+	Action              v1alpha1.Action
+	TargetSize          *intstr.IntOrString
+	allQualifyingPods   sets.String
+	podsManagedByPolicy sets.String
+	targetMet           bool
+}
+
+func newPolicyInfo(namespace string, name string, action v1alpha1.Action, targetSize *intstr.IntOrString) *PolicyInfo {
+	policy := &PolicyInfo{
+		Namespace:           namespace,
+		Name:                name,
+		Action:              action,
+		TargetSize:          targetSize,
+		allQualifyingPods:   sets.NewString(),
+		podsManagedByPolicy: sets.NewString(),
+		targetMet:           false,
+	}
+	return policy
+}
+
+type PolicyInfos map[string]map[string]*PolicyInfo
+
+func NewPolicyInfos() PolicyInfos {
+	return make(PolicyInfos)
+}
+
+func (p *PolicyInfo) merge(existing *PolicyInfo) *PolicyInfo {
+	existing.Action = p.Action
+	existing.TargetSize = p.TargetSize
+	existing.targetMet = p.targetMet
+	existing.allQualifyingPods = sets.NewString()
+	existing.podsManagedByPolicy = sets.NewString()
+
+	if len(p.allQualifyingPods) > 0 {
+		pods := p.allQualifyingPods.List()
+		for _, pod := range pods {
+			existing.allQualifyingPods.Insert(pod)
+		}
+	}
+
+	if len(p.podsManagedByPolicy) > 0 {
+		pods := p.podsManagedByPolicy.List()
+		for _, pod := range pods {
+			existing.podsManagedByPolicy.Insert(pod)
+		}
+	}
+
+	return existing
+}
+
+func (p *PolicyInfo) removePodIfPresent(pod *corev1.Pod) error {
+	key, keyError := framework.GetPodKey(pod)
+	if keyError != nil {
+		return keyError
+	}
+
+	if !p.PodQualifiesForPolicy(key) {
+		return nil
+	}
+
+	p.allQualifyingPods = p.allQualifyingPods.Delete(key)
+
+	if p.PodIsManagedByPolicy(key) {
+		p.podsManagedByPolicy = p.podsManagedByPolicy.Delete(key)
+	}
+
+	err := p.setTargetMet()
+	return err
+}
+
+func (p *PolicyInfo) addPodIfNotPresent(pod *corev1.Pod) error {
+	key, keyError := framework.GetPodKey(pod)
+	if keyError != nil {
+		return keyError
+	}
+
+	//if pod is already in the list, do nothing
+	if p.PodQualifiesForPolicy(key) {
+		return nil
+	}
+
+	p.allQualifyingPods = p.allQualifyingPods.Insert(key)
+
+	targetErr := p.setTargetMet()
+	if targetErr != nil {
+		return targetErr
+	}
+
+	//if target was met without also adding the pod to the "managed" list, then nothing else to do
+	if p.targetMet {
+		return nil
+	}
+
+	p.podsManagedByPolicy = p.podsManagedByPolicy.Insert(key)
+
+	err := p.setTargetMet()
+	return err
+}
+
+func (p *PolicyInfo) calculateTrueTargetSize() (int, error) {
+	specTarget := p.TargetSize
+	lenAllPods := len(p.allQualifyingPods)
+
+	target, err := intstr.GetScaledValueFromIntOrPercent(specTarget, lenAllPods, false)
+
+	if err != nil {
+		return 0, err
+	}
+
+	if p.Action == v1alpha1.ActionMustNot {
+		target = lenAllPods - target
+	}
+
+	return target, nil
+}
+
+func (p *PolicyInfo) setTargetMet() error {
+	target, calcError := p.calculateTrueTargetSize()
+	if calcError != nil {
+		return calcError
+	}
+
+	managedCount := len(p.podsManagedByPolicy)
+	p.targetMet = managedCount >= target //since the TargetSize is rounded down, the expectation that it will only meet/equal and never exceed
+	return nil
+}
+
+func (p *PolicyInfo) PodQualifiesForPolicy(podKey string) bool {
+	return p.allQualifyingPods.Has(podKey)
+}
+
+func (p *PolicyInfo) PodIsManagedByPolicy(podKey string) bool {
+	return p.podsManagedByPolicy.Has(podKey)
+}

--- a/pkg/plugins/placementpolicy/core/policy_test.go
+++ b/pkg/plugins/placementpolicy/core/policy_test.go
@@ -132,7 +132,6 @@ func TestAddPodIfNotPresent(t *testing.T) {
 					t.Errorf("Expected added pod to be managed by policy but it isn't.")
 				}
 			}
-
 		})
 	}
 }

--- a/pkg/plugins/placementpolicy/core/policy_test.go
+++ b/pkg/plugins/placementpolicy/core/policy_test.go
@@ -1,0 +1,341 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/Azure/placement-policy-scheduler-plugins/apis/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func TestAddPodIfNotPresent(t *testing.T) {
+	two := intstr.FromInt(2)
+	fiftyPercent := intstr.FromString("50%")
+	eightyPercent := intstr.FromString("80%")
+
+	type desiredResult struct {
+		newPodManaged bool
+		targetMet     bool
+		valuesChanged bool
+	}
+
+	tests := []struct {
+		name                 string
+		action               v1alpha1.Action
+		target               intstr.IntOrString
+		currentQualifiedPods sets.String
+		currentManagedPods   sets.String
+		podToAdd             *corev1.Pod
+		want                 desiredResult
+	}{
+		{
+			name:                 "Must - new pod managed - target not met",
+			action:               v1alpha1.ActionMust,
+			target:               two,
+			currentQualifiedPods: sets.NewString(),
+			currentManagedPods:   sets.NewString(),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID("pod1")}},
+			want:                 desiredResult{newPodManaged: true, targetMet: false, valuesChanged: true},
+		},
+		{
+			name:                 "Must - new pod managed - target met",
+			action:               v1alpha1.ActionMust,
+			target:               fiftyPercent,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4", "pod5"),
+			currentManagedPods:   sets.NewString("pod1", "pod2"),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod6", UID: types.UID("pod6")}},
+			want:                 desiredResult{newPodManaged: true, targetMet: true, valuesChanged: true},
+		},
+		{
+			name:                 "MustNot with no pods - new pod managed - target met",
+			action:               v1alpha1.ActionMustNot,
+			target:               fiftyPercent,
+			currentQualifiedPods: sets.NewString(),
+			currentManagedPods:   sets.NewString(),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID("pod1")}},
+			want:                 desiredResult{newPodManaged: true, targetMet: true, valuesChanged: true},
+		},
+		{
+			name:                 "MustNot with pods - new pod managed - target met",
+			action:               v1alpha1.ActionMustNot,
+			target:               fiftyPercent,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4", "pod5"),
+			currentManagedPods:   sets.NewString("pod1", "pod2"),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod6", UID: types.UID("pod6")}},
+			want:                 desiredResult{newPodManaged: true, targetMet: true, valuesChanged: true},
+		},
+		{
+			name:                 "Must - new pod not managed - target met",
+			action:               v1alpha1.ActionMust,
+			target:               two,
+			currentQualifiedPods: sets.NewString("pod1", "pod2"),
+			currentManagedPods:   sets.NewString("pod1", "pod2"),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3", UID: types.UID("pod3")}},
+			want:                 desiredResult{newPodManaged: false, targetMet: true, valuesChanged: true},
+		},
+		{
+			name:                 "MustNot - new pod not managed - target met",
+			action:               v1alpha1.ActionMustNot,
+			target:               eightyPercent,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4"),
+			currentManagedPods:   sets.NewString("pod1"),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod5", UID: types.UID("pod5")}},
+			want:                 desiredResult{newPodManaged: false, targetMet: true, valuesChanged: true},
+		},
+		{
+			name:                 "pod already included - no change",
+			action:               v1alpha1.ActionMust,
+			target:               two,
+			currentQualifiedPods: sets.NewString("pod1", "pod2"),
+			currentManagedPods:   sets.NewString("pod1", "pod2"),
+			podToAdd:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", UID: types.UID("pod2")}},
+			want:                 desiredResult{valuesChanged: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policyUnderTest := newPolicyInfo("ns", tt.name, tt.action, &tt.target)
+			policyUnderTest.allQualifyingPods = tt.currentQualifiedPods
+			policyUnderTest.podsManagedByPolicy = tt.currentManagedPods
+			policyUnderTest.setTargetMet() //since testing includes "no changes", this must be computed before addition
+			copyOfOriginal := policyUnderTest
+
+			policyUnderTest.addPodIfNotPresent(tt.podToAdd)
+			resultTargetMet := policyUnderTest.targetMet
+
+			if !tt.want.valuesChanged {
+				originalQualifying := len(copyOfOriginal.allQualifyingPods)
+				resultQualifying := len(policyUnderTest.allQualifyingPods)
+				if resultQualifying != originalQualifying {
+					t.Errorf("No changes expected but allQualifyingPods changed. Original: %v Final: %v", originalQualifying, resultQualifying)
+				}
+				originalManaged := len(copyOfOriginal.podsManagedByPolicy)
+				resultManaged := len(policyUnderTest.podsManagedByPolicy)
+				if resultManaged != originalManaged {
+					t.Errorf("No changes expected but podsManagedByPolicy did. Original: %v Final: %v", originalManaged, resultManaged)
+				}
+				if copyOfOriginal.targetMet != resultTargetMet {
+					t.Errorf("No changes expected but targetMet changed. Original: %v Final: %v", copyOfOriginal.targetMet, resultTargetMet)
+				}
+			} else {
+				if tt.want.targetMet != resultTargetMet {
+					t.Errorf("targetMet mismatch. Expected: %v Actual: %v", tt.want.targetMet, resultTargetMet)
+				}
+
+				key, _ := framework.GetPodKey(tt.podToAdd)
+				if tt.want.newPodManaged && !policyUnderTest.PodIsManagedByPolicy(key) {
+					t.Errorf("Expected added pod to be managed by policy but it isn't.")
+				}
+			}
+
+		})
+	}
+}
+
+func TestRemovePodIfPresent(t *testing.T) {
+	two := intstr.FromInt(2)
+	three := intstr.FromInt(3)
+	seventyFivePercent := intstr.FromString("75%")
+	eightyPercent := intstr.FromString("80%")
+
+	type desiredResult struct {
+		qualifyingCount int
+		managedCount    int
+		targetMet       bool
+	}
+
+	tests := []struct {
+		name                 string
+		action               v1alpha1.Action
+		target               intstr.IntOrString
+		currentQualifiedPods sets.String
+		currentManagedPods   sets.String
+		podToRemove          *corev1.Pod
+		want                 desiredResult
+	}{
+		{
+			name:                 "pod not included - no change",
+			action:               v1alpha1.ActionMust,
+			target:               two,
+			currentQualifiedPods: sets.NewString("pod1", "pod2"),
+			currentManagedPods:   sets.NewString("pod1", "pod2"),
+			podToRemove:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod5", UID: types.UID("pod5")}},
+			want:                 desiredResult{qualifyingCount: 2, managedCount: 2, targetMet: true},
+		},
+		{
+			name:                 "Must - target not met",
+			action:               v1alpha1.ActionMust,
+			target:               two,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4"),
+			currentManagedPods:   sets.NewString("pod1", "pod3"),
+			podToRemove:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID("pod1")}},
+			want:                 desiredResult{qualifyingCount: 3, managedCount: 1, targetMet: false},
+		},
+		{
+			name:                 "Must - target met",
+			action:               v1alpha1.ActionMust,
+			target:               seventyFivePercent,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4"),
+			currentManagedPods:   sets.NewString("pod1", "pod2", "pod3"),
+			podToRemove:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod4", UID: types.UID("pod4")}},
+			want:                 desiredResult{qualifyingCount: 3, managedCount: 3, targetMet: true},
+		},
+		{
+			name:                 "MustNot - target met",
+			action:               v1alpha1.ActionMustNot,
+			target:               eightyPercent,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4"),
+			currentManagedPods:   sets.NewString("pod1", "pod3"),
+			podToRemove:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID("pod1")}},
+			want:                 desiredResult{qualifyingCount: 3, managedCount: 1, targetMet: true},
+		},
+		{
+			name:                 "MustNot - target not met",
+			action:               v1alpha1.ActionMustNot,
+			target:               three,
+			currentQualifiedPods: sets.NewString("pod1", "pod2", "pod3", "pod4", "pod5", "pod6", "pod7", "pod8", "pod9"),
+			currentManagedPods:   sets.NewString("pod1", "pod2", "pod3"),
+			podToRemove:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3", UID: types.UID("pod3")}},
+			want:                 desiredResult{qualifyingCount: 8, managedCount: 2, targetMet: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policyUnderTest := newPolicyInfo("ns", tt.name, tt.action, &tt.target)
+			policyUnderTest.allQualifyingPods = tt.currentQualifiedPods
+			policyUnderTest.podsManagedByPolicy = tt.currentManagedPods
+			policyUnderTest.setTargetMet() //since testing includes "no changes", this must be computed before removal
+
+			policyUnderTest.removePodIfPresent(tt.podToRemove)
+
+			actualQualifyingCount := len(policyUnderTest.allQualifyingPods)
+			if actualQualifyingCount != tt.want.qualifyingCount {
+				t.Errorf("allQualifyingPods length: expected: %v actual: %v", tt.want.qualifyingCount, actualQualifyingCount)
+			}
+
+			actualManagedCount := len(policyUnderTest.podsManagedByPolicy)
+			if actualManagedCount != tt.want.managedCount {
+				t.Errorf("podsManagedByPolicy length: expected: %v actual: %v", tt.want.managedCount, actualManagedCount)
+			}
+
+			if policyUnderTest.targetMet != tt.want.targetMet {
+				t.Errorf("targetMet: expected: %v actual: %v", tt.want.targetMet, policyUnderTest.targetMet)
+			}
+		})
+	}
+}
+
+func TestPolicyInfoMerge(t *testing.T) {
+	type policyInput struct {
+		action        v1alpha1.Action
+		target        intstr.IntOrString
+		qualifiedPods sets.String
+		managedPods   sets.String
+	}
+
+	tenPercent := intstr.FromString("10%")
+	five := intstr.FromInt(5)
+
+	tests := []struct {
+		name     string
+		existing policyInput
+		updated  policyInput
+	}{
+		{
+			name:     "action updated",
+			existing: policyInput{action: v1alpha1.ActionMust, target: tenPercent, qualifiedPods: sets.NewString("pod1"), managedPods: sets.NewString("pod1")},
+			updated:  policyInput{action: v1alpha1.ActionMustNot, target: tenPercent, qualifiedPods: sets.NewString("pod1"), managedPods: sets.NewString("pod1")},
+		},
+		{
+			name:     "target updated",
+			existing: policyInput{action: v1alpha1.ActionMust, target: five, qualifiedPods: sets.NewString("pod1"), managedPods: sets.NewString("pod1")},
+			updated:  policyInput{action: v1alpha1.ActionMust, target: tenPercent, qualifiedPods: sets.NewString("pod1"), managedPods: sets.NewString("pod1")},
+		},
+		{
+			name:     "number of pods updated",
+			existing: policyInput{action: v1alpha1.ActionMust, target: five, qualifiedPods: sets.NewString("pod1"), managedPods: sets.NewString()},
+			updated:  policyInput{action: v1alpha1.ActionMust, target: five, qualifiedPods: sets.NewString("pod1", "pod2"), managedPods: sets.NewString("pod2")},
+		},
+		{
+			name:     "value of pods updated",
+			existing: policyInput{action: v1alpha1.ActionMust, target: five, qualifiedPods: sets.NewString("pod5", "pod25"), managedPods: sets.NewString("pod5")},
+			updated:  policyInput{action: v1alpha1.ActionMust, target: five, qualifiedPods: sets.NewString("pod1", "pod2"), managedPods: sets.NewString("pod2")},
+		},
+	}
+
+	policyNamespace := "ns"
+	policyName := "placement_policy"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existingPolicy := &PolicyInfo{
+				Namespace:           policyNamespace,
+				Name:                policyName,
+				Action:              tt.existing.action,
+				TargetSize:          &tt.existing.target,
+				allQualifyingPods:   tt.existing.qualifiedPods,
+				podsManagedByPolicy: tt.existing.managedPods,
+			}
+			existingPolicy.setTargetMet()
+
+			updatedPolicy := &PolicyInfo{
+				Namespace:           policyNamespace,
+				Name:                policyName,
+				Action:              tt.updated.action,
+				TargetSize:          &tt.updated.target,
+				allQualifyingPods:   tt.updated.qualifiedPods,
+				podsManagedByPolicy: tt.updated.managedPods,
+			}
+			updatedPolicy.setTargetMet()
+
+			final := updatedPolicy.merge(existingPolicy)
+			final.setTargetMet()
+
+			if final.Action != updatedPolicy.Action {
+				t.Errorf("Unexpected Action value - existing: %v, updated: %v, final: %v", existingPolicy.Action, updatedPolicy.Action, final.Action)
+			}
+
+			if final.TargetSize != updatedPolicy.TargetSize {
+				t.Errorf("Unexpected TargetSize value - existing: %v, updated: %v, final: %v", existingPolicy.TargetSize, updatedPolicy.TargetSize, final.TargetSize)
+			}
+
+			finalQualifying := final.allQualifyingPods.List()
+			for _, qp := range finalQualifying {
+				if !updatedPolicy.allQualifyingPods.Has(qp) {
+					t.Errorf("Unexpected value in allQualifyingPods - value %v exists in final and not in updated", qp)
+				}
+			}
+
+			updatedQualifying := updatedPolicy.allQualifyingPods.List()
+			for _, up := range updatedQualifying {
+				if !final.allQualifyingPods.Has(up) {
+					t.Errorf("Unexpected value in allQualifyingPods - value %v exists in updated and not in final", up)
+				}
+			}
+
+			finalManaged := final.podsManagedByPolicy.List()
+			for _, qp := range finalManaged {
+				if !updatedPolicy.podsManagedByPolicy.Has(qp) {
+					t.Errorf("Unexpected value in podsManagedByPolicy - value %v exists in final and not in updated", qp)
+				}
+			}
+
+			updatedManaged := updatedPolicy.podsManagedByPolicy.List()
+			for _, up := range updatedManaged {
+				if !final.podsManagedByPolicy.Has(up) {
+					t.Errorf("Unexpected value in podsManagedByPolicy - value %v exists in updated and not in final", up)
+				}
+			}
+
+			if final.targetMet != updatedPolicy.targetMet {
+				t.Errorf("Unexpected targetMet value - existing: %v, updated: %v, final: %v", existingPolicy.targetMet, updatedPolicy.targetMet, final.targetMet)
+			}
+		})
+	}
+}

--- a/pkg/plugins/placementpolicy/placementpolicy.go
+++ b/pkg/plugins/placementpolicy/placementpolicy.go
@@ -67,10 +67,8 @@ func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) 
 				case *corev1.Pod:
 					return true
 				case cache.DeletedFinalStateUnknown:
-					if _, ok := t.Obj.(*corev1.Pod); ok {
-						return true
-					}
-					return false
+					_, ok := t.Obj.(*corev1.Pod)
+					return ok
 				default:
 					return false
 				}

--- a/pkg/plugins/placementpolicy/placementpolicy.go
+++ b/pkg/plugins/placementpolicy/placementpolicy.go
@@ -203,7 +203,7 @@ func (p *Plugin) PreScore(ctx context.Context, state *framework.CycleState, pod 
 		return framework.NewStatus(framework.Error, "failed to cast state data")
 	}
 
-	//if pod has already been added to the policy in (Pre)Filter, don't need to do anything with scoring
+	// if pod has already been added to the policy in (Pre)Filter, don't need to do anything with scoring
 	if d.status == Added {
 		return framework.NewStatus(framework.Success, "")
 	}

--- a/pkg/plugins/placementpolicy/placementpolicy.go
+++ b/pkg/plugins/placementpolicy/placementpolicy.go
@@ -165,7 +165,7 @@ func (p *Plugin) Filter(ctx context.Context, state *framework.CycleState, pod *c
 	// defined in the placement policy chosen for the pod.
 	nodeMatchesLabels := checkHasLabels(node.Labels, d.nodeLabels)
 
-	podKey, keyError := framework.GetPodKey(pod)
+	podKey, err := framework.GetPodKey(pod)
 	if keyError != nil {
 		return framework.NewStatus(framework.Error, "pod key not found")
 	}

--- a/pkg/plugins/placementpolicy/placementpolicy.go
+++ b/pkg/plugins/placementpolicy/placementpolicy.go
@@ -67,7 +67,7 @@ func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) 
 				case *corev1.Pod:
 					return true
 				case cache.DeletedFinalStateUnknown:
-					if pod, ok := t.Obj.(*corev1.Pod); ok {
+					if _, ok := t.Obj.(*corev1.Pod); ok {
 						return true
 					}
 					return false

--- a/pkg/plugins/placementpolicy/state.go
+++ b/pkg/plugins/placementpolicy/state.go
@@ -1,50 +1,21 @@
 package placementpolicy
 
 import (
-	"github.com/Azure/placement-policy-scheduler-plugins/apis/v1alpha1"
 	"github.com/Azure/placement-policy-scheduler-plugins/pkg/plugins/placementpolicy/core"
-
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-)
-
-type PodPolicyStatus int16
-
-const (
-	Matched PodPolicyStatus = iota
-	Added
-	NoPolicy
 )
 
 type stateData struct {
 	name       string
 	policy     *core.PolicyInfo
 	nodeLabels map[string]string
-	status     PodPolicyStatus
 }
 
-func NewStateData(name string, pp *v1alpha1.PlacementPolicy, info *core.PolicyInfo, status PodPolicyStatus) framework.StateData {
-	return &stateData{
-		name:       name,
-		policy:     info,
-		nodeLabels: pp.Spec.NodeSelector.MatchLabels,
-		status:     status,
-	}
-}
-
-func ModifiedStateData(name string, info *core.PolicyInfo, nodeLabels map[string]string, status PodPolicyStatus) framework.StateData {
+func NewStateData(name string, info *core.PolicyInfo, nodeLabels map[string]string) framework.StateData {
 	return &stateData{
 		name:       name,
 		policy:     info,
 		nodeLabels: nodeLabels,
-		status:     status,
-	}
-}
-
-func EmptyStateData(name string) framework.StateData {
-	return &stateData{
-		name:       name,
-		nodeLabels: map[string]string{},
-		status:     NoPolicy,
 	}
 }
 

--- a/pkg/plugins/placementpolicy/state.go
+++ b/pkg/plugins/placementpolicy/state.go
@@ -7,17 +7,35 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
+type PodPolicyStatus int16
+
+const (
+	Matched PodPolicyStatus = iota
+	Added
+)
+
 type stateData struct {
-	name string
-	pp   *v1alpha1.PlacementPolicy
-	info *core.PolicyInfo
+	name       string
+	policy     *core.PolicyInfo
+	nodeLabels map[string]string
+	status     PodPolicyStatus
 }
 
-func NewStateData(name string, pp *v1alpha1.PlacementPolicy, info *core.PolicyInfo) framework.StateData {
+func NewStateData(name string, pp *v1alpha1.PlacementPolicy, info *core.PolicyInfo, status PodPolicyStatus) framework.StateData {
 	return &stateData{
-		name: name,
-		pp:   pp,
-		info: info,
+		name:       name,
+		policy:     info,
+		nodeLabels: pp.Spec.NodeSelector.MatchLabels,
+		status:     status,
+	}
+}
+
+func ModifedStateData(name string, info *core.PolicyInfo, nodeLabels map[string]string, status PodPolicyStatus) framework.StateData {
+	return &stateData{
+		name:       name,
+		policy:     info,
+		nodeLabels: nodeLabels,
+		status:     status,
 	}
 }
 

--- a/pkg/plugins/placementpolicy/state.go
+++ b/pkg/plugins/placementpolicy/state.go
@@ -2,6 +2,7 @@ package placementpolicy
 
 import (
 	"github.com/Azure/placement-policy-scheduler-plugins/apis/v1alpha1"
+	"github.com/Azure/placement-policy-scheduler-plugins/pkg/plugins/placementpolicy/core"
 
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -9,12 +10,14 @@ import (
 type stateData struct {
 	name string
 	pp   *v1alpha1.PlacementPolicy
+	info *core.PolicyInfo
 }
 
-func NewStateData(name string, pp *v1alpha1.PlacementPolicy) framework.StateData {
+func NewStateData(name string, pp *v1alpha1.PlacementPolicy, info *core.PolicyInfo) framework.StateData {
 	return &stateData{
 		name: name,
 		pp:   pp,
+		info: info,
 	}
 }
 

--- a/pkg/plugins/placementpolicy/state.go
+++ b/pkg/plugins/placementpolicy/state.go
@@ -12,6 +12,7 @@ type PodPolicyStatus int16
 const (
 	Matched PodPolicyStatus = iota
 	Added
+	NoPolicy
 )
 
 type stateData struct {
@@ -30,12 +31,20 @@ func NewStateData(name string, pp *v1alpha1.PlacementPolicy, info *core.PolicyIn
 	}
 }
 
-func ModifedStateData(name string, info *core.PolicyInfo, nodeLabels map[string]string, status PodPolicyStatus) framework.StateData {
+func ModifiedStateData(name string, info *core.PolicyInfo, nodeLabels map[string]string, status PodPolicyStatus) framework.StateData {
 	return &stateData{
 		name:       name,
 		policy:     info,
 		nodeLabels: nodeLabels,
 		status:     status,
+	}
+}
+
+func EmptyStateData(name string) framework.StateData {
+	return &stateData{
+		name:       name,
+		nodeLabels: map[string]string{},
+		status:     NoPolicy,
 	}
 }
 


### PR DESCRIPTION
Re: #25 

[The capacity scheduling plugin](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/capacityscheduling) was used for frame of reference. A collection of policy information is kept in-memory on the PlacementPolicyManager. Instead of annotations, the policy info in the collection includes 2 sets:
- all pods that qualify for / fall under the policy
- all pods assigned to nodes in accordance with the policy ("managed by")

An event handler was attached to the pod informer so pod deletion can trigger updating the in-memory version of the policy accordingly. Additionally, the custom info object is included in the state object added to cycle state as a part of `PreFilter` and `PreScore` stages so that `Filter` and `Score` stages have access to it as well.