### PR TITLE
chore: remove `privileged: true` and `runAsUser: 0` security context

### DIFF
--- a/manifest_staging/charts/placement-policy-scheduler-plugins/templates/deployment.yaml
+++ b/manifest_staging/charts/placement-policy-scheduler-plugins/templates/deployment.yaml
@@ -22,9 +22,6 @@ spec:
         - --config=/etc/schedulerconfig/scheduler-config.yaml
         image: {{ .Values.image }}
         name: pp-plugins-scheduler
-        securityContext:
-          privileged: true
-          runAsUser: 0
         volumeMounts:
         - name: scheduler-config
           mountPath: /etc/schedulerconfig

--- a/manifest_staging/deploy/kube-scheduler-configuration.yml
+++ b/manifest_staging/deploy/kube-scheduler-configuration.yml
@@ -357,9 +357,6 @@ spec:
         image: ghcr.io/azure/placement-policy-scheduler-plugins/placement-policy:v0.1.0
         imagePullPolicy: IfNotPresent
         name: pp-plugins-scheduler
-        securityContext:
-          privileged: true
-          runAsUser: 0
         volumeMounts:
         - name: scheduler-config
           mountPath: /etc/schedulerconfig


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- `privileged: true` and `runAsUser: 0` security context was required for reading `scheduler.conf`. The plugin no longer relies on the conf, so removing the extra permissions.