### PR TITLE
Example with spot nodepool

### DIFF
--- a/examples/basic-mixed-node-pools/README.md
+++ b/examples/basic-mixed-node-pools/README.md
@@ -1,0 +1,199 @@
+# Running Placement Policy Scheduler Plugins in Mixed Node Cluster
+
+## AKS demo
+
+#### 1. Create an [AKS](https://docs.microsoft.com/en-us/azure/aks/) cluster
+
+```sh
+# Create a resource group in South Central US
+az group create --name multinodepool --location southcentralus
+
+# Create a basic single-node pool AKS cluster; the Basic load balancer SKU is not supported so you must use Standard
+az aks create \
+    --resource-group multinodepool \
+    --name multinodepoolcluster \
+    --vm-set-type VirtualMachineScaleSets \
+    --node-count 3 \
+    --generate-ssh-keys \
+    --load-balancer-sku standard
+
+# Get credentials for cluster access for use in current session
+az aks get-credentials --resource-group multinodepool --name multinodepoolcluster
+
+# Add a second node pool with priority equaling Spot
+az aks nodepool add \
+    --resource-group multinodepool \
+    --cluster-name multinodepoolcluster \
+    --name spotnodepool \
+    --priority Spot \
+    --eviction-policy Delete \
+    --spot-max-price -1 \
+    --enable-cluster-autoscaler \
+    --min-count 1 \
+    --max-count 3
+```
+>**Important**: The nodes in the newly created _spotnodepool_ are created with a taint of `kubernetes.azure.com/scalesetpriority=spot:NoSchedule`
+
+#### 2. Deploy placement-policy-scheduler-plugins as a secondary scheduler
+
+The container images for the scheduler plugin is available in GitHub Container Registry.
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/Azure/placement-policy-scheduler-plugins/main/deploy/kube-scheduler-configuration.yml
+```
+
+<details>
+<summary>Output</summary>
+
+```
+customresourcedefinition.apiextensions.k8s.io/placementpolicies.placement-policy.scheduling.x-k8s.io created
+configmap/pp-scheduler-config created
+clusterrole.rbac.authorization.k8s.io/system:pp-plugins-scheduler created
+clusterrolebinding.rbac.authorization.k8s.io/pp-plugins-scheduler created
+clusterrolebinding.rbac.authorization.k8s.io/pp-plugins-scheduler:system:auth-delegator created
+rolebinding.rbac.authorization.k8s.io/pp-plugins-scheduler-as-kube-scheduler created
+clusterrolebinding.rbac.authorization.k8s.io/pp-plugins-scheduler-as-kube-scheduler created
+serviceaccount/pp-plugins-scheduler created
+deployment.apps/pp-plugins-scheduler created
+```
+</details>
+
+#### 3. Choose node selector
+
+Node labels are one path to indicate the applicable nodes for a given policy. The Azure scaleset priority label (`kubernetes.azure.com/scalesetpriority: <priority>`) is appropriate to identify spot nodes.
+
+```sh
+az aks nodepool list --resource-group multinodepool --cluster-name multinodepoolcluster --query "[].{Name:name, NodeLabels:nodeLabels, Priority:scaleSetPriority, Taints:nodeTaints}"
+```
+
+<details>
+<summary>Output</summary>
+
+```json
+[
+  {
+    "Name": "nodepool1",
+    "NodeLabels": null,
+    "Priority": null,
+    "Taints": null
+  },
+  {
+    "Name": "spotnodepool",
+    "NodeLabels": {
+      "kubernetes.azure.com/scalesetpriority": "spot"
+    },
+    "Priority": "Spot",
+    "Taints": [
+      "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"
+    ]
+  }
+]
+```
+</details>
+
+The node pool created with the cluster (_nodepool1_) lacks labels, priority and taints. Node pool _spotnodepool_ has `Priority` equal to `Spot`, node label `kubernetes.azure.com/scalesetpriority:spot` and taint `kubernetes.azure.com/scalesetpriority=spot:NoSchedule` as expected.
+
+#### 5. Deploy a `PlacementPolicy` CRD
+
+```yaml
+apiVersion: placement-policy.scheduling.x-k8s.io/v1alpha1
+kind: PlacementPolicy
+metadata:
+  name: mixednodepools-strict-must-spot
+spec:
+  weight: 100
+  enforcementMode: Strict
+  podSelector:
+    matchLabels:
+      app: nginx
+  nodeSelector:
+    matchLabels:
+      kubernetes.azure.com/scalesetpriority: spot
+  policy:
+    action: Must
+    targetSize: 40%
+```
+
+<details>
+<summary>Output</summary>
+
+```
+placementpolicy.placement-policy.scheduling.x-k8s.io/mixednodepools-strict-must-spot created
+```
+</details>
+
+#### 6. Deploy a `Deployment` with replicas
+
+The desired outcome is 10 pods running with the provided spec. When running the placement policy scheduler as a second scheduler, the name of the desired scheduler must be included in the definition. 
+
+>Since all nodes in _spotnodepool_ have a taint, a corresponding toleration **must** be included.
+
+```yml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      schedulerName: placement-policy-plugins-scheduler
+      containers:
+      - name: nginx
+        image: nginx
+      tolerations:
+      - key: "kubernetes.azure.com/scalesetpriority"
+        operator: "Exists"
+        effect: "NoSchedule"
+```
+
+<details>
+<summary>Output</summary>
+
+```
+deployment.apps/nginx-deployment created
+```
+</details>
+
+#### 7. Validate node assignment
+
+```sh
+kubectl get po -o wide -l app=nginx --sort-by="{.spec.nodeName}" -o wide
+```
+
+<details>
+<summary>Output</summary>
+
+```sh
+NAME                                READY   STATUS    RESTARTS   AGE   IP           NODE                                   NOMINATED NODE   READINESS GATES
+nginx-deployment-5cf7bbf99b-2hd42   1/1     Running   0          93s   10.244.1.4   aks-nodepool1-25514715-vmss000000      <none>           <none>
+nginx-deployment-5cf7bbf99b-d6g8g   1/1     Running   0          93s   10.244.1.5   aks-nodepool1-25514715-vmss000000      <none>           <none>
+nginx-deployment-5cf7bbf99b-6krbw   1/1     Running   0          93s   10.244.0.5   aks-nodepool1-25514715-vmss000001      <none>           <none>
+nginx-deployment-5cf7bbf99b-bpgmh   1/1     Running   0          93s   10.244.0.4   aks-nodepool1-25514715-vmss000001      <none>           <none>
+nginx-deployment-5cf7bbf99b-7d8lf   1/1     Running   0          93s   10.244.2.8   aks-nodepool1-25514715-vmss000002      <none>           <none>
+nginx-deployment-5cf7bbf99b-z69v6   1/1     Running   0          93s   10.244.2.9   aks-nodepool1-25514715-vmss000002      <none>           <none>
+nginx-deployment-5cf7bbf99b-24xgw   1/1     Running   0          93s   10.244.4.5   aks-spotnodepool-40924876-vmss000002   <none>           <none>
+nginx-deployment-5cf7bbf99b-554wh   1/1     Running   0          93s   10.244.4.4   aks-spotnodepool-40924876-vmss000002   <none>           <none>
+nginx-deployment-5cf7bbf99b-dn48d   1/1     Running   0          93s   10.244.4.2   aks-spotnodepool-40924876-vmss000002   <none>           <none>
+nginx-deployment-5cf7bbf99b-j7f7l   1/1     Running   0          93s   10.244.4.3   aks-spotnodepool-40924876-vmss000002   <none>           <none>
+```
+
+As expected, four out of the ten pods created are running on nodes within _spotnodepool_. This aligns with the 40% `targetSize` set in the _mixednodepools-strict-must-spot_ `PlacementPolicy`.
+</details>
+
+#### 8. Clean up
+
+- Delete [AKS](https://docs.microsoft.com/en-us/azure/aks/) cluster
+
+```bash
+az group delete --name multinodepool --yes --no-wait
+```

--- a/examples/basic-mixed-node-pools/demo_deployment.yml
+++ b/examples/basic-mixed-node-pools/demo_deployment.yml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      schedulerName: placement-policy-plugins-scheduler
+      containers:
+      - name: nginx
+        image: nginx
+      tolerations:
+      - key: "kubernetes.azure.com/scalesetpriority"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/examples/basic-mixed-node-pools/v1alpha1_placementpolicy_mixednodepools.yml
+++ b/examples/basic-mixed-node-pools/v1alpha1_placementpolicy_mixednodepools.yml
@@ -1,0 +1,16 @@
+apiVersion: placement-policy.scheduling.x-k8s.io/v1alpha1
+kind: PlacementPolicy
+metadata:
+  name: mixednodepools-strict-must-spot
+spec:
+  weight: 100
+  enforcementMode: Strict
+  podSelector:
+    matchLabels:
+      app: nginx
+  nodeSelector:
+    matchLabels:
+      kubernetes.azure.com/scalesetpriority: spot
+  policy:
+    action: Must
+    targetSize: 40%


### PR DESCRIPTION
Since one of the scenarios that inspired this project revolved around mixed nodepools and being able to deploy a % of a workload to spot/ephemeral nodes, I created a sample walk-through similar to that using Harvest VMs except with the second nodepool having a `Priority` equal to `spot`.

I created a separate deployment for this sample so the `toleration` could be included without risk of touching/breaking other samples or tests by adding it to the existing replicaset.

Signed-off-by: Cara MacLaughlin <cmaclaughlin@microsoft.com>

